### PR TITLE
fix: revert enable/disable via SIDEKIQ_CRON_ENABLE flag

### DIFF
--- a/lib/sidekiq/cron/launcher.rb
+++ b/lib/sidekiq/cron/launcher.rb
@@ -39,11 +39,9 @@ module Sidekiq
   end
 end
 
-if ENV['SIDEKIQ_CRON_ENABLE'] != '0'
-  Sidekiq.configure_server do
-    # require  Sidekiq original launcher
-    require 'sidekiq/launcher'
+Sidekiq.configure_server do
+  # require  Sidekiq original launcher
+  require 'sidekiq/launcher'
 
-    ::Sidekiq::Launcher.prepend(Sidekiq::Cron::Launcher)
-  end
+  ::Sidekiq::Launcher.prepend(Sidekiq::Cron::Launcher)
 end


### PR DESCRIPTION
We discovered from last Friday's incident that the SIDEKIQ_CRON_
ENABLE flag is in practical usage overshadowed by SIDEKIQ_STARTUP_
CHECKS being set to 0, because disabling Sidekiq's scheduler also
disables sidekiq-cron from launching (thanks to OOP inheritance).
Proposing to undo that addition from https://github.com/OneSignal/sidekiq-cron/pull/1
as we're not using the flag in any meaningful way.