### PR TITLE
fix: increase 60s enqueue window to 600s (before removing)

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -597,7 +597,7 @@ module Sidekiq
         last_cron_time = parsed_cron.previous_time(current_time).utc
           # or could it be?
         #last_cron_time = last_time(current_time)
-        return false if (current_time.to_i - last_cron_time.to_i) > 60
+        return false if (current_time.to_i - last_cron_time.to_i) > 600
         true
       end
 


### PR DESCRIPTION
https://github.com/ondrejbartas/sidekiq-cron/pull/73 describes an
issue where sidekiq-cron's developers were having an issue with
enqueues happening too OFTEN/at odd times, which seems to be the
motivation to add an artibary 1-minute-long window during which
cron jobs can be enqueued.

The problem is, if there are too many jobs for the number of
enqueueing processes to keep up, we start dropping jobs because
by the time we get around to enqueueing them, we have left the
1-min window and sidekiq-cron considers that "invalid". This is
the cause of multiple headaches in the past so this is commit 1 of
2 to try to do something about it. This commit raises the window
of opportunity from 1 minute to 10 minutes - should not be so long
as to let jobs re-enqueue too often, but long enough that our
group of sidekiq processes should be fast enough to enqueue them
before the window expires.

If we still experience missed enqueues after this change, we can
remove this `not_past_scheduled_time` check entirely.